### PR TITLE
Call testbuild.sh with -x option to set it fail fast for check build …

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -172,12 +172,13 @@ function install_tools {
 
 function run_builds {
   local ncpus=`grep -c ^processor /proc/cpuinfo`
+  local options="-si -j $ncpus"
 
-  $nuttx/tools/testbuild.sh -si -j $ncpus $WD/testlist/${build}list.dat
-  if [ $? != 0 ]; then
-    echo "ERROR: $BUILD build failed (error $?)"
-    exit 1
+  if [ "X$build" = "Xcheck" ]; then
+    options="$options -x"
   fi
+
+  $nuttx/tools/testbuild.sh $options $WD/testlist/${build}list.dat
 }
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
…error

For PR check build, call testbuild.sh with -x option to set it fail fast if
build error occured. Note that for full build, it keeps on going build anyway.

Change-Id: I46b77cc4632dd2c8e1749ab81a275fa1ff5a505c
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>