### PR TITLE
Get the full directory name of the cibuild.sh no matter where called …

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -18,7 +18,7 @@
 # under the License.
 set -e -x
 
-WD=$PWD
+WD=$(cd $(dirname $0) && pwd)
 nuttx=$WD/../nuttx
 apps=$WD/../apps
 tools=$WD/../tools


### PR DESCRIPTION
…from

Or it would fail to set nuttx/apps/tools/prebuilt dirs correctly when cibuild.sh
is not called by 'cd testing; ./cibuild.sh'. For example, it would break jenkins
groovy script which call with ./testing/cibuild.sh.

Change-Id: I8a9d4a6534578a472952668c0172cd6f5bedff8e
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>