### PR TITLE
cibuild.sh: decouple -b option to do run_builds only

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -199,6 +199,7 @@ while [ ! -z "$1" ]; do
   -b )
     shift
     build="$1"
+    run_builds
     break
     ;;
   -s )
@@ -210,9 +211,3 @@ while [ ! -z "$1" ]; do
   esac
   shift
 done
-
-if [ ! -z "$build" ]; then
-  install_tools
-  setup_repos
-  run_builds
-fi


### PR DESCRIPTION
1. In nuttx and apps PR check build, github action/jenkins/travis CI would
checkout repos accordingly. So decouple -b option to do run_builds only.
2. And if do builds starting from testing repo, call cibuild.sh as below:
./cibuild.sh -i -s -b check or ./cibuild.sh -i -s -b full

Change-Id: I5cd0b87aed37ddab117d17aa5b72744c2db2aac6
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>