### PR TITLE
cibuild.sh: remove -si option since testbuild.sh updated

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -172,7 +172,7 @@ function install_tools {
 
 function run_builds {
   local ncpus=`grep -c ^processor /proc/cpuinfo`
-  local options="-si -j $ncpus"
+  local options="-j $ncpus"
 
   if [ "X$build" = "Xcheck" ]; then
     options="$options -x"


### PR DESCRIPTION
Since -si/sl options have been removed from testbuild.sh, so remove
it here.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>