### PR TITLE
fulllist: remove sim:mtdpart and sim:mtdrwb configs

### DIFF
--- a/testlist/fulllist.dat
+++ b/testlist/fulllist.dat
@@ -31,6 +31,8 @@
 
 /sim
 -sim:cxxtest
+-sim:mtdpart
+-sim:mtdrwb
 -sim:nxwm
 -sim:rpproxy
 -sim:rpserver


### PR DESCRIPTION
Remove sim:mtdpart and sim:mtdrwb configs since i386 libz not available
now in Apache Jenkins slaves. Revert this change once i386 libz installed.

Build error logs:
/usr/bin/ld: skipping incompatible //usr/lib/x86_64-linux-gnu/libz.so when searching for -lz
/usr/bin/ld: skipping incompatible //usr/lib/x86_64-linux-gnu/libz.a when searching for -lz
/usr/bin/ld: cannot find -lz
collect2: error: ld returned 1 exit status

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>