### PR TITLE
Revert "fulllist: remove sim:mtdpart and sim:mtdrwb configs"

### DIFF
--- a/testlist/fulllist.dat
+++ b/testlist/fulllist.dat
@@ -31,8 +31,6 @@
 
 /sim
 -sim:cxxtest
--sim:mtdpart
--sim:mtdrwb
 -sim:nxwm
 -sim:rpproxy
 -sim:rpserver


### PR DESCRIPTION
since INFRA fix this issue:
https://github.com/apache/infrastructure-p6/pull/258