### PR TITLE
Add Dockerfile for CI system and hook into GitHub Actions

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Docker-Linux
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    paths:
+      - 'docker/linux/**'
+
+  # Run builds for any PRs.
+  pull_request:
+    paths:
+      - 'docker/linux/**'
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: nuttx-ci-linux
+
+jobs:
+  # Push image to GitHub Packages.
+  push:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/nuttx-ci-linux
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Build Linux image
+        run: |
+          echo "Building Linux Image using cache from $IMAGE_TAG"
+
+          docker build \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from $IMAGE_TAG \
+            --tag $IMAGE_TAG \
+            -f ./docker/linux/Dockerfile ./docker/
+        
+      - name: Push Linux image
+        if: (github.event_name == 'push') && (github.ref == 'refs/heads/master')
+        run: |
+          docker push $IMAGE_TAG

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,0 +1,167 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:19.04 AS builder-base
+# NOTE WE ARE NOT REMOVEING APT CACHE.
+# This should only be used for temp build images that artifacts will be copied from
+RUN apt-get update -qq && apt-get install -y -qq \
+  curl \
+  xz-utils
+
+###############################################################################
+# Base image that should be used to prepare tools from nuttx-tools
+###############################################################################
+FROM builder-base AS nuttx-tools
+
+RUN apt-get install -y -qq \
+  flex \
+  bison \
+  gperf \
+  libncurses5-dev \
+  make 
+
+RUN mkdir /tools
+WORKDIR /tools
+
+RUN mkdir -p /tools/nuttx-tools
+RUN curl -s -L https://bitbucket.org/nuttx/tools/get/9ad3e1ee75c7.tar.gz \
+  | tar -C nuttx-tools --strip-components=1 -xz
+
+RUN cd nuttx-tools/kconfig-frontends \
+  && ./configure --enable-mconf --disable-gconf --disable-qconf --enable-static --prefix=/tools/kconfig-frontends \
+  && make install
+
+RUN cd nuttx-tools \
+  && mkdir genromfs \
+  && tar -C genromfs --strip-components=1 -xf genromfs-0.5.2.tar.gz \
+  && cd genromfs \
+  && make install PREFIX=/tools/genromfs
+
+CMD [ "/bin/bash" ]
+
+###############################################################################
+# Base image that should be used to prepare arch build images
+###############################################################################
+FROM builder-base AS nuttx-toolchain-base
+
+RUN mkdir /tools
+WORKDIR /tools
+
+###############################################################################
+# Build image for tool required by ARM builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-arm
+# Download the latest ARM GCC toolchain prebuilt by ARM
+RUN mkdir gcc-arm-none-eabi && \
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D" \
+  | tar -C gcc-arm-none-eabi --strip-components 1 -xj
+
+###############################################################################
+# Build image for tool required by Pinguino builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-pinguino
+# Download the pinguino compilers. Note this includes both 8bit and 32bit
+# toolchains and builds for multiple host systems. Only copy what is needed.
+RUN mkdir pinguino-compilers && \
+  curl -s -L "https://github.com/PinguinoIDE/pinguino-compilers/archive/62db5158d7f6d41c6fadb05de81cc31dd81a1958.tar.gz" \
+  | tar -C pinguino-compilers --strip-components=2 --wildcards -xz */linux64
+
+###############################################################################
+# Build image for tool required by RISCV builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
+# Download the latest RISCV GCC toolchain prebuilt by SiFive
+RUN mkdir riscv64-unknown-elf-gcc && \
+  curl -s -L "https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz" \
+  | tar -C riscv64-unknown-elf-gcc --strip-components 1 -xz
+
+###############################################################################
+# Build image for tool required by ESP32 builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
+# Download the latest ESP32 GCC toolchain prebuilt by Espressif
+RUN mkdir xtensa-esp32-elf-gcc && \
+  curl -s -L "https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar.xz" \
+  | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
+
+
+###############################################################################
+# Final Docker image used for running CI system.  This includes all toolchains
+# supported by the CI system.
+###############################################################################
+FROM ubuntu:19.04
+LABEL maintainer="dev@nuttx.apache.org"
+
+RUN dpkg --add-architecture i386
+# This is used for the final images so make sure to not store apt cache
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+  git \
+  build-essential \
+  wget \
+  libx11-dev \
+  libxext-dev \
+  u-boot-tools \
+  lib32z1-dev \
+  libc6-dev-i386 \
+  libx11-dev:i386 \
+  libxext-dev:i386 \
+  curl \
+  gettext \
+  libcurl4-openssl-dev \
+  xxd \
+  unzip \
+  python3 \
+  python3-pip \
+  && rm -rf /var/lib/apt/lists/*
+
+
+# Configure out base setup for adding python packages
+ENV PIP_DISABLE_PIP_VERSION_CHECK=true
+# This disables the cache with value 0. We do not want caching as it
+# increases the images size.
+ENV PIP_NO_CACHE_DIR=0
+# We are using the minimal python installation from the system so include
+# setuptools and also wheel so we can use the binary releases of packages
+# instead of requiring them to be compiled.
+RUN pip3 install setuptools wheel
+
+RUN mkdir /tools
+WORKDIR /tools
+
+# Pull in the tools we just built for nuttx
+COPY --from=nuttx-tools /tools/genromfs/ /tools/genromfs/
+ENV PATH="/tools/genromfs/usr/bin:$PATH"
+COPY --from=nuttx-tools /tools/kconfig-frontends/ kconfig-frontends/
+ENV PATH="/tools/kconfig-frontends/bin:$PATH"
+
+# ARM toolchain
+COPY --from=nuttx-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/
+ENV PATH="/tools/gcc-arm-none-eabi/bin:$PATH"
+
+COPY --from=nuttx-toolchain-pinguino /tools/pinguino-compilers/p32/ pinguino-compilers/p32/
+ENV PATH="/tools/pinguino-compilers/p32/bin:$PATH"
+#COPY --from=nuttx-toolchain-pinguino /tools/pinguino-compilers/p8/ pinguino-compilers/p8/
+#ENV PATH="/tools/pinguino-compilers/p8/bin:$PATH"
+
+# RISCV toolchain
+COPY --from=nuttx-toolchain-riscv /tools/riscv64-unknown-elf-gcc/ riscv64-unknown-elf-gcc/
+ENV PATH="/tools/riscv64-unknown-elf-gcc/bin:$PATH"
+ 
+# ESP32 toolchain
+COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32-elf-gcc/ xtensa-esp32-elf-gcc/
+ENV PATH="/tools/xtensa-esp32-elf-gcc/bin:$PATH"
+RUN pip3 install esptool
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This is a reworking of the Docker container to be used with the GitHub Action CI job for github.com/apache/incubator-nuttx

This should likely replace the PR #13 producing a more modular and smaller docker image.  This will also build the docker image on a PR, but will also publish it to this project only on merge.