### PR TITLE
cibuild.sh: call testbuild.sh with '-e -Wno-cpp' option defaultly

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -289,7 +289,7 @@ function run_builds {
   options+="-j $ncpus"
 
   for build in $builds; do
-    $nuttx/tools/testbuild.sh $options $build
+    $nuttx/tools/testbuild.sh $options -e -Wno-cpp $build
   done
 }
 


### PR DESCRIPTION
So suppress the nightly and check build warnings with pre-processor directive #warning in GCC.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>