### PR TITLE
CI: build arm-11 instead of arm-13 for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-13, mips-riscv-x86-xtensa, sim]
+        boards: [arm-11, mips-riscv-x86-xtensa, sim]
 
     steps:
     - name: Checkout nuttx repo


### PR DESCRIPTION
Sync with https://github.com/apache/incubator-nuttx-apps/pull/173