### PR TITLE
cibuild.sh: enable -Werror for precheck and nightly build defaultly

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -289,7 +289,7 @@ function run_builds {
   options+="-j $ncpus"
 
   for build in $builds; do
-    $nuttx/tools/testbuild.sh $options -e -Wno-cpp $build
+    $nuttx/tools/testbuild.sh $options -e "-Wno-cpp -Werror" $build
   done
 }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/incubator-nuttx/pull/792 merged in, and then all the existing warnings fixed. So defer to merge it now.