### PR TITLE
Fix the warning of undefined input we were using on the build action

### DIFF
--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -12,6 +12,10 @@
 #
 
 name: ci-container
+inputs:
+  run:  # id of input
+    description: 'Commands to run'
+    required: true
 runs:
   using: 'docker'
   image: 'docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux'


### PR DESCRIPTION
## Summary
The github action that we had defined for running builds in the container did not have the input `run` defined, so there were warning annotations on every build.

## Impact
Removes warning from all the Linux builds

## Testing
The warning annotation should not exist anymore in the CI check.
![image](https://user-images.githubusercontent.com/173245/83364417-126efd00-a356-11ea-8c72-72c473017c37.png)
