### PR TITLE
Add support for building avr targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, mips-riscv-x86-xtensa, sim]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim]
     steps:
     - name: Checkout nuttx repo
       uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-12, mips-riscv-x86-xtensa, sim]
+        boards: [arm-12, avr-mips-riscv-x86-xtensa, sim]
 
     steps:
     - name: Checkout nuttx repo

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -36,7 +36,7 @@ EXTRA_PATH=
 
 case $os in
   Darwin)
-    install="python-tools u-boot-tools discoteq-flock elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain"
+    install="python-tools u-boot-tools discoteq-flock elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain"
     mkdir -p ${prebuilt}/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
     ;;
@@ -212,6 +212,17 @@ function xtensa-esp32-gcc-toolchain {
   fi
   xtensa-esp32-elf-gcc --version
   pip3 install esptool
+}
+
+function avr-gcc-toolchain {
+  if ! type avr-gcc > /dev/null; then
+    case $os in
+      Darwin)
+        brew tap osx-cross/avr
+        brew install avr-gcc
+        ;;
+    esac
+  fi
 }
 
 function c-cache {

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:19.04 AS builder-base
+FROM ubuntu:19.10 AS builder-base
 # NOTE WE ARE NOT REMOVEING APT CACHE.
 # This should only be used for temp build images that artifacts will be copied from
 RUN apt-get update -qq && apt-get install -y -qq \
@@ -122,7 +122,7 @@ RUN cp /tools/esp-idf/examples/get-started/hello_world/build/partition_table/par
 # Final Docker image used for running CI system.  This includes all toolchains
 # supported by the CI system.
 ###############################################################################
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 LABEL maintainer="dev@nuttx.apache.org"
 
 RUN dpkg --add-architecture i386
@@ -132,6 +132,8 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
   build-essential \
   gcc \
   gcc-multilib \
+  gcc-avr \
+  avr-libc \
   wget \
   libx11-dev \
   libxext-dev \

--- a/testlist/avr-mips-riscv-x86-xtensa.dat
+++ b/testlist/avr-mips-riscv-x86-xtensa.dat
@@ -1,3 +1,10 @@
+# We do not have a toolchain for avr32 outside of Microchip login wall.
+# The work was never upstreamed to GCC.
+
+/avr
+-avr32dev1:nsh
+-avr32dev1:ostest
+
 # PINGUINOL toolchain doesn't provide macOS binaries
 # with the same name
 # /mips,CONFIG_MIPS32_TOOLCHAIN_PINGUINOL


### PR DESCRIPTION
## Summary
Adds AVR GCC compiler to Darwin environment and to Linux Docker container. 
Adds AVR configurations to CI targets

Note we are not using the Microchip toolchain because it is behind a login wall.  The Homebrew tap and the Ubuntu version are both quite stable and up-to-date

This is also bumping the base Ubuntu version from 19.04 -> 19.10 as 19.04 is EOL.