### PR TITLE
Disable AVR until we get some warnings resolved

### DIFF
--- a/testlist/avr-mips-riscv-x86-xtensa.dat
+++ b/testlist/avr-mips-riscv-x86-xtensa.dat
@@ -1,9 +1,9 @@
 # We do not have a toolchain for avr32 outside of Microchip login wall.
 # The work was never upstreamed to GCC.
 
-/avr
--avr32dev1:nsh
--avr32dev1:ostest
+#/avr
+#-avr32dev1:nsh
+#-avr32dev1:ostest
 
 # PINGUINOL toolchain doesn't provide macOS binaries
 # with the same name


### PR DESCRIPTION
## Summary
This removes the avr targets from the ci build until we can address the warnings in the OS for the architecture.  This should be reverted later, but unblocks other builds.