### PR TITLE
Re-Enable AVR now that master builds AVR correctly

### DIFF
--- a/testlist/avr-mips-riscv-x86-xtensa.dat
+++ b/testlist/avr-mips-riscv-x86-xtensa.dat
@@ -1,9 +1,9 @@
 # We do not have a toolchain for avr32 outside of Microchip login wall.
 # The work was never upstreamed to GCC.
 
-#/avr
-#-avr32dev1:nsh
-#-avr32dev1:ostest
+/avr
+-avr32dev1:nsh
+-avr32dev1:ostest
 
 # PINGUINOL toolchain doesn't provide macOS binaries
 # with the same name


### PR DESCRIPTION
Reverts apache/incubator-nuttx-testing#51