### PR TITLE
Additions for ESP32

### DIFF
--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -20,5 +20,6 @@ runs:
   using: 'docker'
   image: 'docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux'
   args:
+    - "/bin/bash"
     - "-c"
     - ${{ inputs.run }}

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -182,7 +182,7 @@ ENV PATH="/tools/pinguino-compilers/p32/bin:$PATH"
 # RISCV toolchain
 COPY --from=nuttx-toolchain-riscv /tools/riscv64-unknown-elf-gcc/ riscv64-unknown-elf-gcc/
 ENV PATH="/tools/riscv64-unknown-elf-gcc/bin:$PATH"
- 
+
 # ESP32 toolchain
 COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32-elf-gcc/ xtensa-esp32-elf-gcc/
 COPY --from=nuttx-toolchain-esp32 /tools/esp-idf/ esp-idf/
@@ -191,4 +191,4 @@ RUN mkdir -p /tools/blobs/esp32core
 COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp32core/
 RUN pip3 install esptool
 
-ENTRYPOINT [ "/bin/bash" ]
+CMD [ "/bin/bash" ]

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -104,12 +104,16 @@ RUN bash -c "\
   cd esp-idf && \
   ./install.sh"
 
+# Provide an option for disabling DOUT mode, so that the default one,
+# DIO, can be used (for instance, for flashing a DevKitC module)
+ARG FLASH_DOUT_ENABLED=y
 # We run this is generate the default bootloader and partition table binaries
 RUN bash -c "\
   cd esp-idf && \
   source ./export.sh && \
   cd examples/get-started/hello_world && \
   make defconfig && \
+  if [[ '${FLASH_DOUT_ENABLED}' == y ]]; then echo 'CONFIG_ESPTOOLPY_FLASHMODE_DOUT=y' >> sdkconfig; fi && \
   idf.py bootloader partition_table"
 
 RUN mkdir /tools/blobs

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -110,7 +110,6 @@ RUN bash -c "\
   source ./export.sh && \
   cd examples/get-started/hello_world && \
   make defconfig && \
-  echo "CONFIG_ESPTOOLPY_FLASHMODE_DOUT=y" >> sdkconfig && \
   idf.py bootloader partition_table"
 
 RUN mkdir /tools/blobs

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -185,6 +185,7 @@ ENV PATH="/tools/riscv64-unknown-elf-gcc/bin:$PATH"
  
 # ESP32 toolchain
 COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32-elf-gcc/ xtensa-esp32-elf-gcc/
+COPY --from=nuttx-toolchain-esp32 /tools/esp-idf/ esp-idf/
 ENV PATH="/tools/xtensa-esp32-elf-gcc/bin:$PATH"
 RUN mkdir -p /tools/blobs/esp32core
 COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp32core/


### PR DESCRIPTION
## Summary
Two small changes that I found useful having while setting up a Dockerized environment for testing NuttX on the ESP32 platform.

## Impact
Should cause none.

## Testing
Ran a dockerized build of the esp32-core:nsh configuration and flashed it onto my DevKitC module, worked ok.
