### PR TITLE
CI: Add bloaty utility to the ci tools

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -36,12 +36,12 @@ EXTRA_PATH=
 
 case $os in
   Darwin)
-    install="python-tools u-boot-tools discoteq-flock elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain"
+    install="python-tools u-boot-tools discoteq-flock elf-toolchain gen-romfs kconfig-frontends bloaty arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain"
     mkdir -p ${prebuilt}/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
     ;;
   Linux)
-    install="python-tools gen-romfs gperf kconfig-frontends arm-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain c-cache"
+    install="python-tools gen-romfs gperf kconfig-frontends bloaty arm-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain c-cache"
     ;;
 esac
 
@@ -134,6 +134,19 @@ function kconfig-frontends {
     touch aclocal.m4 Makefile.in
     make install
     cd $tools; git clean -xfd
+  fi
+}
+
+function bloaty {
+  add_path $prebuilt/bloaty/bin
+  if [ ! -f "$prebuilt/bloaty/bin/bloaty" ]; then
+    git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty-src
+    cd bloaty-src
+    mkdir -p $prebuilt/bloaty
+    cmake -DCMAKE_SYSTEM_PREFIX_PATH=$prebuilt/bloaty
+    make install -j 6
+    cd $prebuilt
+    rm -rf bloaty-src
   fi
 }
 

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -25,12 +25,15 @@ RUN apt-get update -qq && apt-get install -y -qq \
 ###############################################################################
 FROM builder-base AS nuttx-tools
 
-RUN apt-get install -y -qq \
+RUN apt-get update -qq && apt-get install -y -qq \
   flex \
   bison \
   gperf \
   libncurses5-dev \
-  make
+  make \
+  cmake \
+  g++ \
+  git
 
 RUN mkdir /tools
 WORKDIR /tools
@@ -48,6 +51,12 @@ RUN cd nuttx-tools \
   && tar -C genromfs --strip-components=1 -xf genromfs-0.5.2.tar.gz \
   && cd genromfs \
   && make install PREFIX=/tools/genromfs
+
+RUN mkdir bloaty -p \
+  && git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty \
+  && cd bloaty \
+  && cmake -DCMAKE_SYSTEM_PREFIX_PATH=/tools/bloaty \
+  && make install
 
 CMD [ "/bin/bash" ]
 
@@ -96,7 +105,7 @@ RUN mkdir xtensa-esp32-elf-gcc && \
   curl -s -L "https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar.xz" \
   | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xJ
 
-RUN apt-get install -y -qq --no-install-recommends \
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
   git bison gperf python python-pip python-setuptools make cmake ninja-build ccache libffi-dev libssl-dev libusb-1.0
 RUN git clone --depth 1 --shallow-submodules --recursive https://github.com/espressif/esp-idf.git
 # This is unfortunatly going to re-download some of the same toolchains, but will only be used in the context of esp-idf
@@ -174,6 +183,8 @@ COPY --from=nuttx-tools /tools/genromfs/ /tools/genromfs/
 ENV PATH="/tools/genromfs/usr/bin:$PATH"
 COPY --from=nuttx-tools /tools/kconfig-frontends/ kconfig-frontends/
 ENV PATH="/tools/kconfig-frontends/bin:$PATH"
+COPY --from=nuttx-tools /tools/bloaty/ bloaty/
+ENV PATH="/tools/bloaty/bin:$PATH"
 
 # ARM toolchain
 COPY --from=nuttx-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/


### PR DESCRIPTION
## Summary
Add https://github.com/google/bloaty to the CI tool builds so we can start integrating it into the build flow.

This does not yet change the CI flow to use the utility yet.

## Testing
Was able to run bloaty from the docker image that is created.