### PR TITLE
sim.dat: disable sim:sotest32 config since not work under macOS

### DIFF
--- a/testlist/sim.dat
+++ b/testlist/sim.dat
@@ -5,6 +5,7 @@
 # The recent versions of macOS is 64-bit only
 -sim:loadable
 -sim:module32
+-sim:sotest32
 
 # X11
 # macOS doesn't have X11


### PR DESCRIPTION
## Summary
Disable sim sotest32 config build since it doesn't work on macOS, just like module32 config.

## Impact

## Testing

