### PR TITLE
Update CI Docker Image to use GitHub Container Registery

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
-      IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/nuttx-ci-linux
+      IMAGE_TAG: ghcr.io/${{ github.repository }}/nuttx-ci-linux
     steps:
       - uses: actions/checkout@v2
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: Build Linux image
         run: |

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FROM ubuntu:19.10 AS builder-base
+FROM ubuntu:20.04 AS builder-base
 # NOTE WE ARE NOT REMOVEING APT CACHE.
 # This should only be used for temp build images that artifacts will be copied from
 RUN apt-get update -qq && apt-get install -y -qq \


### PR DESCRIPTION
## Summary
Use the new GitHub Container Registry instead of GitHub Packages for storing the image.  This was just released and resolves a long running frustration where we could not use anonymous pulls from GitHub packages.
https://github.blog/2020-09-01-introducing-github-container-registry/

Important follow on change in another PR will be to point at the new container location.

## Impact
Image will now be uploaded to
ghcr.io/apache/incubator-nuttx-testing:latest instead of docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux:latest