### PR TITLE
CI: Enable ccache for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       DOCKER_BUILDKIT: 1
+      IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/nuttx-ci-linux
 
     strategy:
       matrix:
@@ -63,16 +64,27 @@ jobs:
         timeout_minutes: 10
         max_attempts: 3
         retry_wait_seconds: 10
-        command: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
+        command: docker pull $IMAGE_TAG
 
+    - name: Restore ccache
+      id: ccache
+      uses: actions/cache@v2
+      with:
+        path: ccache
+        key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
+        restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
     - name: Run builds
       uses: ./testing/.github/actions/ci-container
       env:
         BLOBDIR: /tools/blobs
       with:
         run: |
+          export CCACHE_DIR=`pwd`/ccache
           cd testing
-          ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -c -x testlist/${{matrix.boards}}.dat
+          ccache -s
+          ccache -M 400M
+          ccache -c
 
   macOS:
     runs-on: macos-10.15
@@ -107,16 +119,28 @@ jobs:
         repository: apache/incubator-nuttx-testing
         path: testing
 
-    - name: Restore cache
+    - name: Restore tools cache
       id: cache-tools
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       env:
         cache-name: ${{ runner.os }}-cache-tools
       with:
         path: prebuilt
         key: ${{ runner.os }}-tools-${{ hashFiles('./testing/cibuild.sh') }}
 
+    - name: Restore ccache
+      id: ccache
+      uses: actions/cache@v2
+      with:
+        path: ccache
+        key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
+        restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
     - name: Run builds
       run: |
+        export CCACHE_DIR=`pwd`/ccache
         cd testing
-        ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat
+        ./cibuild.sh -i -c -x testlist/${{matrix.boards}}.dat
+        ccache -s
+        ccache -M 400M
+        ccache -c
+

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -383,7 +383,7 @@ function run_builds {
 
   case $os in
     Darwin)
-      ncpus=$(sysctl -n machdep.cpu.thread_count)
+      ncpus=$(sysctl -n hw.ncpu)
       ;;
     Linux)
       ncpus=`grep -c ^processor /proc/cpuinfo`

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -209,6 +209,7 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
   unzip \
   python3 \
   python3-pip \
+  ccache \
   && rm -rf /var/lib/apt/lists/*
 
 
@@ -256,5 +257,25 @@ RUN pip3 install esptool
 # Renesas toolchain
 COPY --from=nuttx-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas-toolchain/rx-elf-gcc/
 ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
+
+# Configure ccache
+RUN mkdir -p /tools/ccache/bin && \
+  ln -sf `which ccache` /tools/ccache/bin/cc && \
+  ln -sf `which ccache` /tools/ccache/bin/c++ && \
+  ln -sf `which ccache` /tools/ccache/bin/clang && \
+  ln -sf `which ccache` /tools/ccache/bin/clang++ && \
+  ln -sf `which ccache` /tools/ccache/bin/gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/p32-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32-elf-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32-elf-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/avr-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/avr-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/rx-elf-gcc
+ENV PATH="/tools/ccache/bin:$PATH"
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
## Summary
Some of our builds especially on MacOS are still fairly slow.  This fix enabled ccache for both Linux and MacOS builds with cross build cache maintained via GitHub Actions cache.

The improvement on MacOS is less but on some Linux builds times are nearly cut in half.