### PR TITLE
make bash abort on error

### DIFF
--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -21,5 +21,5 @@ runs:
   image: 'docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux'
   args:
     - "/bin/bash"
-    - "-c"
+    - "-ce"
     - ${{ inputs.run }}


### PR DESCRIPTION
## Summary

This fixes one of the issues I found with CI. The call on NuttX workflow is like:

<pre>
testbuild.sh
ccache -s
</pre>

and even if `testbuild.sh` failed, since `ccache` didn't, this did not fail the test. 

## Impact

Fixes CI

## Testing

Not possible, will have to do once merged.
