### PR TITLE
cibuild.sh: Remove the flock installation

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -37,7 +37,7 @@ EXTRA_PATH=
 
 case $os in
   Darwin)
-    install="python-tools u-boot-tools discoteq-flock elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain c-cache binutils"
+    install="python-tools u-boot-tools elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain c-cache binutils"
     mkdir -p ${prebuilt}/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
     ;;
@@ -65,17 +65,6 @@ function u-boot-tools {
     case $os in
       Darwin)
         brew install u-boot-tools
-        ;;
-    esac
-  fi
-}
-
-function discoteq-flock {
-  if ! type flock > /dev/null; then
-    case $os in
-      Darwin)
-        brew tap discoteq/discoteq
-        brew install flock
         ;;
     esac
   fi


### PR DESCRIPTION
## Summary
follow up the apps repo change:
```
commit 18137c0fec3cea30871f29238e11ea0f4e8523da
Author: Matias N <matias@protobits.dev>
Date:   Sat Sep 12 00:36:23 2020 -0300

    Fix: ensure archive files do not carry object files from prior builds

    This is the corresponding change to the one on main NuttX repo. In this
    case this involves splitting the build of libapps.a into: a) building
    all applications (which is safely parallelizable), b) adding each
    application's object files to the archive in turns (serial by nature).

    This removes the need for the flock used to protect the parallel build.

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```
## Impact

## Testing

