### PR TITLE
Added renesas precheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim, renesas]
     steps:
     - name: Checkout nuttx repo
       uses: actions/checkout@v2

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -234,7 +234,8 @@ function rx-gcc-toolchain {
   if [ ! -f "$prebuilt/renesas-toolchain/rx-elf-gcc/bin/rx-elf-gcc" ]; then
     case $os in
       Linux)        
-        # Download toolchain source code
+        # Download toolchain source code 
+        # RX toolchain is built from source code. Once prebuilt RX toolchain is made available, the below code snippet can be removed. 
         mkdir -p $prebuilt/renesas-tools/rx/source; cd $prebuilt/renesas-tools/rx/source
         wget --quiet https://gcc-renesas.com/downloads/d.php?f=rx/binutils/4.8.4.201803-gnurx/rx_binutils2.24_2018Q3.tar.gz \
           -O rx_binutils2.24_2018Q3.tar.gz
@@ -257,6 +258,7 @@ function rx-gcc-toolchain {
         cd $prebuilt/renesas-tools/rx/source/gcc 
         chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh
         ./contrib/download_prerequisites
+        sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi
         sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi
         mkdir -p $prebuilt/renesas-tools/rx/build/gcc; cd $prebuilt/renesas-tools/rx/build/gcc
         $prebuilt/renesas-tools/rx/source/gcc/configure --target=rx-elf --prefix=$prebuilt/renesas-toolchain/rx-elf-gcc \

--- a/testlist/all.dat
+++ b/testlist/all.dat
@@ -30,3 +30,9 @@
 /x86_64
 
 /xtensa
+
+/renesas/rx65n/rx65n-grrose
+-rx65n-grrose:ipv6
+
+/renesas/rx65n/rx65n-rsk2mb
+-rx65n-rsk2mb:ipv6

--- a/testlist/renesas.dat
+++ b/testlist/renesas.dat
@@ -1,0 +1,5 @@
+/renesas/rx65n/rx65n-grrose
+-rx65n-grrose:ipv6
+
+/renesas/rx65n/rx65n-rsk2mb
+-rx65n-rsk2mb:ipv6


### PR DESCRIPTION
## Summary
Added renesas pre-check for RX65N
cibuild.sh: Textinfo issue for RX toolchain compilation resolved

## Impact
To enable the renesas pre-check

## Testing
Tested RX toolchain compilation
