### PR TITLE
ci: Handle case where prebuilt was cached but brew install binutils

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -322,6 +322,9 @@ function binutils {
     case $os in
       Darwin)
         brew install binutils
+        # It is possible we cached prebuilt but did brew install so recreate
+        # simlink if it exists
+        rm -f $prebuilt/bintools/bin/objcopy
         ln -s /usr/local/opt/binutils/bin/objcopy $prebuilt/bintools/bin/objcopy
         ;;
     esac


### PR DESCRIPTION
## Summary
We create a simlink in prebuilt for certain tools like objcopy that are brew installed from binutils.  It is likely that we will cache the simlink, but still need to brew install binutils this will fail because we will try to create the symlink again. This change always recreates the symlink if the brew install was required.

## Impact
MacOS CI builds should be more reliable.

## Testing
CI Builds
