### PR TITLE
Add OS specific testlist settings to allow building more targets

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -393,16 +393,20 @@ function run_builds {
   case $os in
     Darwin)
       ncpus=$(sysctl -n hw.ncpu)
+      ostweak=$WD/testlist/macos-tweak.dat
       ;;
     Linux)
       ncpus=`grep -c ^processor /proc/cpuinfo`
+      ostweak=$WD/testlist/linux-tweak.dat
       ;;
   esac
 
   options+="-j $ncpus"
 
   for build in $builds; do
-    $nuttx/tools/testbuild.sh $options -e "-Wno-cpp -Werror" $build
+    tweakedbuild=$(mktemp /tmp/nuttx-testlist.XXXXXX)
+    cat $build $ostweak > $tweakedbuild
+    $nuttx/tools/testbuild.sh $options -e "-Wno-cpp -Werror" $tweakedbuild
   done
 }
 

--- a/testlist/macos-tweak.dat
+++ b/testlist/macos-tweak.dat
@@ -1,0 +1,17 @@
+#### sim ####
+-sim:cxxtest
+
+# CONFIG_SIM_M32=y
+# The recent versions of macOS is 64-bit only
+-sim:loadable
+-sim:module32
+-sim:sotest32
+
+# X11
+# macOS doesn't have X11
+-sim:nsh2
+-sim:nx11
+-sim:nxlines
+-sim:nxwm
+-sim:touchscreen
+

--- a/testlist/sim.dat
+++ b/testlist/sim.dat
@@ -1,11 +1,6 @@
 /sim
+# This target is actually broken (https://github.com/apache/incubator-nuttx/issues/2086)
 -sim:cxxtest
-
-# CONFIG_SIM_M32=y
-# The recent versions of macOS is 64-bit only
--sim:loadable
--sim:module32
--sim:sotest32
 
 # X11
 # macOS doesn't have X11


### PR DESCRIPTION
## Summary
This creates a set of testdata tweak files that can be used to add additional test data on a per OS basis

## Impact
This should let us get better coverage of tests that are only supported by some OS.

## Testing
CI System

We can see this working here.  The cxxtest is skipped on macOS even though it is in the sim.dat file.
```
====================================================================================
Configuration/Tool: sim/unionfs
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Building NuttX...
  Normalize sim/unionfs
====================================================================================
Skipping: sim/touchscreen
====================================================================================
Skipping: sim/cxxtest
====================================================================================
```
