### PR TITLE
testlist/sim.dat: Skip 32bit sim build only for macOS

### DIFF
--- a/testlist/sim.dat
+++ b/testlist/sim.dat
@@ -3,14 +3,16 @@
 
 # CONFIG_SIM_M32=y
 # The recent versions of macOS is 64-bit only
--sim:loadable
--sim:module32
--sim:sotest32
+-Darwin,sim:loadable
+-Darwin,sim:module32
+-Darwin,sim:rpproxy
+-Darwin,sim:rpserver
+-Darwin,sim:sotest32
 
 # X11
 # macOS doesn't have X11
--sim:nsh2
--sim:nx11
--sim:nxlines
--sim:nxwm
--sim:touchscreen
+-Darwin,sim:nsh2
+-Darwin,sim:nx11
+-Darwin,sim:nxlines
+-Darwin,sim:nxwm
+-Darwin,sim:touchscreen


### PR DESCRIPTION
## Summary
To fix the issue: https://github.com/apache/incubator-nuttx/issues/2094
Need merge https://github.com/apache/incubator-nuttx/pull/2128 first.

## Impact
The automation build

## Testing

