### PR TITLE
testlist: Merge avr-mips-riscv-x86-xtensa.dat and renesas.dat into other.dat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim, renesas]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, sim]
     steps:
     - name: Checkout nuttx repo
       uses: actions/checkout@v2
@@ -91,7 +91,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-12, avr-mips-riscv-x86-xtensa, sim]
+        boards: [arm-12, other, sim]
 
     steps:
     - name: Checkout nuttx repo

--- a/testlist/other.dat
+++ b/testlist/other.dat
@@ -1,0 +1,35 @@
+# We do not have a toolchain for avr32 outside of Microchip login wall.
+# The work was never upstreamed to GCC.
+
+/avr
+-avr32dev1:nsh
+-avr32dev1:ostest
+
+/renesas/rx65n/rx65n-grrose
+/renesas/rx65n/rx65n-rsk2mb
+-Darwin,rx65n-grrose:.*
+-Darwin,rx65n-rsk2mb:.*
+
+# PINGUINOL toolchain doesn't provide macOS binaries
+# with the same name
+/mips,CONFIG_MIPS32_TOOLCHAIN_PINGUINOL
+-Darwin,flipnclick-pic32mz:.*
+-Darwin,mirtoo:.*
+-Darwin,pic32mx7mmb:.*
+-Darwin,pic32mx-starterkit:.*
+-Darwin,pic32mz-starterkit:.*
+-Darwin,sure-pic32mx:.*
+-Darwin,ubw32:.*
+
+/risc-v,CONFIG_RV32IM_TOOLCHAIN_GNU_RVGL
+-gapuino:nsh
+-nr5m100-nexys4:nsh
+
+# x86_64-elf-gcc from homebrew doesn't seem to
+# provide __udivdi3 etc for -m32
+/x86
+-Darwin,qemu-i486:.*
+
+/x86_64
+
+/xtensa


### PR DESCRIPTION
## Summary
will remove avr-mips-riscv-x86-xtensa.dat and renesas.dat after the script in nuttx/apps update

## Impact

## Testing

