### PR TITLE
add sim:lvgl to macOS exceptions

### DIFF
--- a/testlist/sim.dat
+++ b/testlist/sim.dat
@@ -16,3 +16,4 @@
 -Darwin,sim:nxlines
 -Darwin,sim:nxwm
 -Darwin,sim:touchscreen
+-Darwin,sim:lvgl


### PR DESCRIPTION
## Summary

LVGL uses X11 which is not available on macOS

## Impact

CI

## Testing

CI

