### PR TITLE
CI: Add Linux headers to docker image

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -230,6 +230,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \
   linux-libc-dev:i386 \
+  linux-headers-generic \
   python3 \
   python3-pip \
   python-is-python3 \

--- a/testlist/sim.dat
+++ b/testlist/sim.dat
@@ -20,3 +20,7 @@
 
 # macOS doesn't have ALSA
 -Darwin,sim:alsa
+
+# Do not build Linux configs
+-Darwin,sim:linux.*
+


### PR DESCRIPTION
## Summary
Add Linux headers to docker image.  This supports simulator targets that are Linux specific such as https://github.com/apache/incubator-nuttx/pull/2158

This also adds a block entry in the testlists for macOS for any sim config that starts with sim:linux this way we don't have to keep adding entries all the time if they are Linux specific.

