### PR TITLE
docker: add gawk to docker

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   make \
   cmake \
   g++ \
+  gawk \
   git
 
 RUN mkdir /tools


### PR DESCRIPTION
## Summary
add gawk to docker, used for build ltp on nuttx
## Impact
no
## Testing
test on local 
