### PR TITLE
CI: Only use approved GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   Linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
       IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/nuttx-ci-linux
@@ -25,122 +25,92 @@ jobs:
     strategy:
       matrix:
         boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, sim]
+
     steps:
-    - name: Checkout nuttx repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx
-        path: nuttx
-        fetch-depth: 0
+      - name: Checkout nuttx repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx
+          ref: master
+          path: sources/nuttx
+          fetch-depth: 1
+      - name: Checkout nuttx repo tags
+        run: git -C sources/nuttx fetch --tags
 
-    - name: Fetch nuttx tags
-      run: |
-        cd nuttx
-        git fetch --tags
+      - name: Checkout apps repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx-apps
+          ref: master
+          path: sources/apps
+          fetch-depth: 1
 
-    - name: Checkout apps repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx-apps
-        path: apps
-        fetch-depth: 0
+      - name: Checkout testing repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx-testing
+          path: sources/testing
+          fetch-depth: 1
 
-    - name: Checkout testing repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx-testing
-        path: testing
+      - name: Docker Login
+        uses: azure/docker-login@v1
+        with:
+          login-server: docker.pkg.github.com
+          username: ${GITHUB_ACTOR}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Docker Login
-      uses: azure/docker-login@v1
-      with:
-        login-server: docker.pkg.github.com
-        username: ${GITHUB_ACTOR}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Docker Pull
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 10
-        max_attempts: 3
-        retry_wait_seconds: 10
-        command: docker pull $IMAGE_TAG
-
-    - name: Restore ccache
-      id: ccache
-      uses: actions/cache@v2
-      with:
-        path: ccache
-        key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
-        restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
-    - name: Run builds
-      uses: ./testing/.github/actions/ci-container
-      env:
-        BLOBDIR: /tools/blobs
-      with:
-        run: |
-          export CCACHE_DIR=`pwd`/ccache
-          cd testing
-          ./cibuild.sh -c -x testlist/${{matrix.boards}}.dat
-          ccache -s
-          ccache -M 400M
-          ccache -c
+      - name: Docker Pull
+        run: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
+      - name: Run builds
+        uses: ./sources/testing/.github/actions/ci-container
+        env:
+          BLOBDIR: /tools/blobs
+        with:
+          run: |
+            echo "::add-matcher::sources/nuttx/.github/gcc.json"
+            export CCACHE_DIR=`pwd`/ccache
+            mkdir $CCACHE_DIR
+            cd sources/testing
+            export ARTIFACTDIR=`pwd`/../../buildartifacts
+            ./cibuild.sh -A -c testlist/${{matrix.boards}}.dat
+            ccache -s
 
   macOS:
     runs-on: macos-10.15
-
     strategy:
       matrix:
         boards: [arm-12, other, sim]
-
     steps:
-    - name: Checkout nuttx repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx
-        path: nuttx
-        fetch-depth: 0
+      - name: Checkout nuttx repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx
+          ref: master
+          path: sources/nuttx
+          fetch-depth: 1
+      - name: Checkout nuttx repo tags
+        run: git -C sources/nuttx fetch --tags
 
-    - name: Fetch nuttx tags
-      run: |
-        cd nuttx
-        git fetch --tags
+      - name: Checkout apps repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx-apps
+          ref: master
+          path: sources/apps
+          fetch-depth: 1
 
-    - name: Checkout apps repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx-apps
-        path: apps
-        fetch-depth: 0
-
-    - name: Checkout testing repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx-testing
-        path: testing
-
-    - name: Restore tools cache
-      id: cache-tools
-      uses: actions/cache@v2
-      env:
-        cache-name: ${{ runner.os }}-cache-tools
-      with:
-        path: prebuilt
-        key: ${{ runner.os }}-tools-${{ hashFiles('./testing/cibuild.sh') }}
-
-    - name: Restore ccache
-      id: ccache
-      uses: actions/cache@v2
-      with:
-        path: ccache
-        key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
-        restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
-    - name: Run builds
-      run: |
-        export CCACHE_DIR=`pwd`/ccache
-        cd testing
-        ./cibuild.sh -i -c -x testlist/${{matrix.boards}}.dat
-        ccache -s
-        ccache -M 400M
-        ccache -c
-
+      - name: Checkout testing repo
+        uses: actions/checkout@v2
+        with:
+          repository: apache/incubator-nuttx-testing
+          path: sources/testing
+          fetch-depth: 1
+      - name: Run Builds
+        run: |
+          echo "::add-matcher::sources/nuttx/.github/gcc.json"
+          export CCACHE_DIR=`pwd`/ccache
+          mkdir $CCACHE_DIR
+          cd sources/testing
+          export ARTIFACTDIR=`pwd`/../../buildartifacts
+          ./cibuild.sh -i -A -c -x testlist/${{matrix.boards}}.dat
+          ccache -s

--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -26,7 +26,6 @@ on:
       - 'docker/linux/**'
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: nuttx-ci-linux
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Super Lint
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_YAML: true


### PR DESCRIPTION
## Summary
See https://github.com/apache/incubator-nuttx/pull/2622

*In addition to the problem listed here this also brings this in-line with the OS workflow files and adds some more linting*

Apache Infrastructure recently made a change to the GitHub projects so that they cannot use actions that are not under the Apache org, GitHub org, or verified.   We were using some outside of this and this prevented builds from running.

### More details:

Policy:

* https://infra.apache.org/github-actions-secrets.html

Discussion builds@apache.org:

* https://lists.apache.org/thread.html/r435c45dfc28ec74e28314aa9db8a216a2b45ff7f27b15932035d3f65%40%3Cbuilds.apache.org%3E

Discussion users@infra.apache.org:

* https://lists.apache.org/thread.html/r900f8f9a874006ed8121bdc901a0d1acccbb340882c1f94dad61a5e9%40%3Cusers.infra.apache.org%3E

## Impact
One drawback is that the docker pull retry action had to be dropped.  We can implement this via bash if needed.

## Testing
CI Runs

