### PR TITLE
nuttx-ci-linux: Install libpython2.7 for xtensa-esp32-elf-gdb

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -106,6 +106,7 @@ RUN mkdir xtensa-esp32-elf-gcc && \
   curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
   | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xz
 
+# Note: xtensa-esp32-elf-gdb is linked to libpython2.7
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends \
   git \
   bison \
@@ -121,7 +122,8 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   ccache \
   libffi-dev \
   libssl-dev \
-  libusb-1.0
+  libusb-1.0 \
+  libpython2.7
 
 RUN git clone --depth 1 --shallow-submodules --recursive https://github.com/espressif/esp-idf.git
 # This is unfortunately going to re-download some of the same toolchains, but will only be used in the context of esp-idf


### PR DESCRIPTION
## Summary
Install libpython2.7 for xtensa-esp32-elf-gdb

root@5b2362eb60c2:/src/nuttx# ldd /tools/xtensa-esp32-elf-gcc/bin/xtensa-esp32-elf-gdb
        linux-vdso.so.1 (0x00007ffeb59f3000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2a7fc31000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2a7fc0e000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f2a7fc09000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f2a7faba000)
        libpython2.7.so.1.0 => /lib/x86_64-linux-gnu/libpython2.7.so.1.0 (0x00007f2a7f74e000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2a7f55c000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2a7fc3f000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f2a7f53e000)
root@5b2362eb60c2:/src/nuttx#

## Impact
increase the image size a bit

## Testing

