### PR TITLE
Dockerfile: APT::Immediate-Configure=0 to workaround failures

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -216,6 +216,7 @@ LABEL maintainer="dev@nuttx.apache.org"
 RUN dpkg --add-architecture i386
 # This is used for the final images so make sure to not store apt cache
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends \
+  -o APT::Immediate-Configure=0 \
   avr-libc \
   build-essential \
   ccache \


### PR DESCRIPTION
## Summary
Workaround the following failure I have with "docker build" on
Docker Desktop on macOS.
It might be related to https://github.com/docker/for-linux/issues/1131.

    E: Could not configure 'libc6:i386'.
    E: Could not perform immediate configuration on 'libgcc-s1:i386'. Please see man 5 apt.conf under APT::Immediate-Configure for details. (2)
    The command '/bin/sh -c apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends   avr-libc   build-essential   ccache   curl   gcc   gcc-avr   gcc-multilib   gettext   git   lib32z1-dev   libc6-dev-i386   libasound2-dev libasound2-dev:i386   libcurl4-openssl-dev   libpulse-dev libpulse-dev:i386   libpython2.7   libx11-dev libx11-dev:i386   libxext-dev libxext-dev:i386   linux-libc-dev:i386   linux-headers-generic   python3   python3-pip   python-is-python3   u-boot-tools   unzip   wget   xxd   && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100

## Impact

## Testing
build and tested locally (with https://github.com/apache/incubator-nuttx-testing/pull/87)