### PR TITLE
Reapply xtensa gdb fix to the right section

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -106,7 +106,6 @@ RUN mkdir xtensa-esp32-elf-gcc && \
   curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
   | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xz
 
-# Note: xtensa-esp32-elf-gdb is linked to libpython2.7
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends \
   git \
   bison \
@@ -122,8 +121,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   ccache \
   libffi-dev \
   libssl-dev \
-  libusb-1.0 \
-  libpython2.7
+  libusb-1.0
 
 RUN git clone --depth 1 --shallow-submodules --recursive https://github.com/espressif/esp-idf.git
 # This is unfortunately going to re-download some of the same toolchains, but will only be used in the context of esp-idf

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -213,6 +213,7 @@ LABEL maintainer="dev@nuttx.apache.org"
 
 RUN dpkg --add-architecture i386
 # This is used for the final images so make sure to not store apt cache
+# Note: xtensa-esp32-elf-gdb is linked to libpython2.7
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq --no-install-recommends \
   avr-libc \
   build-essential \
@@ -228,6 +229,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libasound2-dev libasound2-dev:i386 \
   libcurl4-openssl-dev \
   libpulse-dev libpulse-dev:i386 \
+  libpython2.7 \
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \
   linux-libc-dev:i386 \


### PR DESCRIPTION
## Summary
https://github.com/apache/incubator-nuttx-testing/pull/83 was applied to the wrong instance of apt-get.
this PR fixes it.
## Impact

## Testing
built and tested locally (with https://github.com/apache/incubator-nuttx-testing/pull/86)
