### PR TITLE
Revert "Disable AVR targets on macOS due to homebrew issue"

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -40,6 +40,8 @@ case $os in
     install="python-tools u-boot-tools elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain c-cache binutils"
     mkdir -p ${prebuilt}/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
+    # https://github.com/osx-cross/homebrew-avr/issues/205#issuecomment-760637996
+    brew update
     ;;
   Linux)
     install="python-tools gen-romfs gperf kconfig-frontends arm-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain rx-gcc-toolchain c-cache"

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -40,6 +40,8 @@ case $os in
     install="python-tools u-boot-tools elf-toolchain gen-romfs kconfig-frontends arm-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain avr-gcc-toolchain c-cache binutils"
     mkdir -p ${prebuilt}/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
+    # https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
+    rm -rf /usr/local/bin/2to3
     # https://github.com/osx-cross/homebrew-avr/issues/205#issuecomment-760637996
     brew update
     ;;

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -43,7 +43,7 @@ case $os in
     # https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
     rm -rf /usr/local/bin/2to3
     # https://github.com/osx-cross/homebrew-avr/issues/205#issuecomment-760637996
-    brew update
+    brew update --quiet
     ;;
   Linux)
     install="python-tools gen-romfs gperf kconfig-frontends arm-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain rx-gcc-toolchain c-cache"

--- a/testlist/other.dat
+++ b/testlist/other.dat
@@ -5,14 +5,6 @@
 -avr32dev1:nsh
 -avr32dev1:ostest
 
-# Disable AVR targets on macOS due to homebrew issue
-# https://github.com/osx-cross/homebrew-avr/issues/205
--Darwin,teensy-2\.0:.*
--Darwin,micropendous3:.*
--Darwin,amber:.*
--Darwin,arduino-mega2560:.*
--Darwin,moteino-mega:.*
-
 /renesas/rx65n/rx65n-grrose
 /renesas/rx65n/rx65n-rsk2mb
 -Darwin,rx65n-grrose:.*


### PR DESCRIPTION
Reverts apache/incubator-nuttx-testing#85