### PR TITLE
testlist: Remove gapuino and nr5m100-nexys4 from black list

### DIFF
--- a/testlist/all.dat
+++ b/testlist/all.dat
@@ -19,8 +19,6 @@
 /mips,CONFIG_MIPS32_TOOLCHAIN_PINGUINOL
 
 /risc-v,CONFIG_RV32IM_TOOLCHAIN_GNU_RVGL
--gapuino:nsh
--nr5m100-nexys4:nsh
 
 /sim
 

--- a/testlist/other.dat
+++ b/testlist/other.dat
@@ -22,8 +22,6 @@
 -Darwin,ubw32:.*
 
 /risc-v,CONFIG_RV32IM_TOOLCHAIN_GNU_RVGL
--gapuino:nsh
--nr5m100-nexys4:nsh
 
 # x86_64-elf-gcc from homebrew doesn't seem to
 # provide __udivdi3 etc for -m32


### PR DESCRIPTION
## Summary
since both platform support are removed from mainline

## Impact
No, we never build these platform before.

## Testing

