### PR TITLE
other.dat: Remove the Darwin black list

### DIFF
--- a/testlist/other.dat
+++ b/testlist/other.dat
@@ -1,28 +1,18 @@
+# We do not have a toolchain for avr32 outside of Microchip login wall.
+# The work was never upstreamed to GCC.
 /avr
 -avr32dev1:nsh
 -avr32dev1:ostest
-# x86_64-elf-gcc from homebrew doesn't seem to
-# provide __udivdi3 etc for -m32
-
-/renesas/rx65n/rx65n-grrose
-/renesas/rx65n/rx65n-rsk2mb
--Darwin,rx65n-grrose:.*
--Darwin,rx65n-rsk2mb:.*
 
 # PINGUINOL toolchain doesn't provide macOS binaries
 # with the same name
 /mips,CONFIG_MIPS32_TOOLCHAIN_PINGUINOL
--Darwin,flipnclick-pic32mz:.*
--Darwin,mirtoo:.*
--Darwin,pic32mx7mmb:.*
--Darwin,pic32mx-starterkit:.*
--Darwin,pic32mz-starterkit:.*
--Darwin,sure-pic32mx:.*
--Darwin,ubw32:.*
-# We do not have a toolchain for avr32 outside of Microchip login wall.
-# The work was never upstreamed to GCC.
+
+/renesas/rx65n/rx65n-grrose
+/renesas/rx65n/rx65n-rsk2mb
 
 /x86
--Darwin,qemu-i486:.*
 
+# x86_64-elf-gcc from homebrew doesn't seem to
+# provide __udivdi3 etc for -m32
 /x86_64


### PR DESCRIPTION
## Summary
since macOS build never reference other.dat

## Impact

## Testing

